### PR TITLE
Add UCSBOrganization E2E test

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/web/UCSBOrganizationWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/UCSBOrganizationWebIT.java
@@ -1,0 +1,50 @@
+package edu.ucsb.cs156.example.web;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.example.WebTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class UCSBOrganizationWebIT extends WebTestCase {
+  @Test
+  public void admin_user_can_create_ucsborganization() throws Exception {
+    setupUser(true);
+
+    page.getByText("UCSBOrganization").click();
+
+    page.getByText("Create UCSBOrganization").click();
+    assertThat(page.getByText("Create New UCSBOrganization")).isVisible();
+
+    page.getByTestId("UCSBOrganizationForm-orgCode").fill("TEST");
+    page.getByTestId("UCSBOrganizationForm-orgTranslationShort").fill("Test Org");
+    page.getByTestId("UCSBOrganizationForm-orgTranslation").fill("Test Organization");
+
+    page.getByTestId("UCSBOrganizationForm-submit").click();
+
+    assertThat(page.getByTestId("UCSBOrganizationTable-cell-row-0-col-orgCode")).hasText("TEST");
+    assertThat(page.getByTestId("UCSBOrganizationTable-cell-row-0-col-orgTranslationShort"))
+        .hasText("Test Org");
+    assertThat(page.getByTestId("UCSBOrganizationTable-cell-row-0-col-orgTranslation"))
+        .hasText("Test Organization");
+  }
+
+  @Test
+  public void regular_user_cannot_create_ucsborganization() throws Exception {
+    setupUser(false);
+
+    page.getByText("UCSBOrganization").click();
+
+    assertThat(page.getByText("Create UCSBOrganization")).not().isVisible();
+    assertThat(page.getByTestId("UCSBOrganizationTable-cell-row-0-col-orgCode")).not().isVisible();
+  }
+}


### PR DESCRIPTION
Closes #126 

I added UCSBOrganizationWebIT.java to test UCSBOrganization frontend behavior.

The test verifies that an admin user can create a UCSBOrganization from the UI and a regular user cannot see the Create UCSBOrganization button