### PR TITLE
Add E2E tests for RecommendationRequest 

### DIFF
--- a/src/test/java/edu/ucsb/cs156/example/integration/RecommendationRequestIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/integration/RecommendationRequestIT.java
@@ -1,0 +1,136 @@
+package edu.ucsb.cs156.example.integration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import edu.ucsb.cs156.example.entities.RecommendationRequest;
+import edu.ucsb.cs156.example.repositories.RecommendationRequestRepository;
+import edu.ucsb.cs156.example.repositories.UserRepository;
+import edu.ucsb.cs156.example.services.CurrentUserService;
+import edu.ucsb.cs156.example.services.GrantedAuthoritiesService;
+import edu.ucsb.cs156.example.testconfig.TestConfig;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+@ActiveProfiles("integration")
+@Import(TestConfig.class)
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class RecommendationRequestIT {
+
+  @Autowired public CurrentUserService currentUserService;
+  @Autowired public GrantedAuthoritiesService grantedAuthoritiesService;
+  @Autowired RecommendationRequestRepository recommendationRequestRepository;
+  @Autowired public MockMvc mockMvc;
+  @Autowired public ObjectMapper mapper;
+
+  @MockitoBean UserRepository userRepository;
+
+  @WithMockUser(roles = {"USER"})
+  @Test
+  public void test_that_logged_in_user_can_get_by_id_when_the_id_exists() throws Exception {
+    LocalDateTime dateRequested = LocalDateTime.parse("2024-01-01T00:00:00");
+    LocalDateTime dateNeeded = LocalDateTime.parse("2024-05-01T00:00:00");
+
+    RecommendationRequest request =
+        RecommendationRequest.builder()
+            .requesterEmail("student@ucsb.edu")
+            .professorEmail("professor@ucsb.edu")
+            .explanation("Need a recommendation for grad school.")
+            .dateRequested(dateRequested)
+            .dateNeeded(dateNeeded)
+            .done(false)
+            .build();
+
+    recommendationRequestRepository.save(request);
+
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/recommendationrequest?id=1"))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String expectedJson = mapper.writeValueAsString(request);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_post_a_new_recommendation_request() throws Exception {
+    LocalDateTime dateRequested = LocalDateTime.parse("2024-01-01T00:00:00");
+    LocalDateTime dateNeeded = LocalDateTime.parse("2024-05-01T00:00:00");
+
+    RecommendationRequest expectedRequest =
+        RecommendationRequest.builder()
+            .id(1L)
+            .requesterEmail("student@ucsb.edu")
+            .professorEmail("professor@ucsb.edu")
+            .explanation("Need a recommendation for grad school.")
+            .dateRequested(dateRequested)
+            .dateNeeded(dateNeeded)
+            .done(false)
+            .build();
+
+    MvcResult response =
+        mockMvc
+            .perform(
+                post("/api/recommendationrequest/post"
+                        + "?requesterEmail=student@ucsb.edu"
+                        + "&professorEmail=professor@ucsb.edu"
+                        + "&explanation=Need a recommendation for grad school."
+                        + "&dateRequested=2024-01-01T00:00:00"
+                        + "&dateNeeded=2024-05-01T00:00:00"
+                        + "&done=false")
+                    .with(csrf()))
+            .andExpect(status().isOk())
+            .andReturn();
+
+    String expectedJson = mapper.writeValueAsString(expectedRequest);
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString);
+  }
+
+  @WithMockUser(roles = {"ADMIN", "USER"})
+  @Test
+  public void an_admin_user_can_delete_a_recommendation_request() throws Exception {
+    LocalDateTime dateRequested = LocalDateTime.parse("2024-01-01T00:00:00");
+    LocalDateTime dateNeeded = LocalDateTime.parse("2024-05-01T00:00:00");
+
+    RecommendationRequest request =
+        RecommendationRequest.builder()
+            .requesterEmail("student@ucsb.edu")
+            .professorEmail("professor@ucsb.edu")
+            .explanation("Need a recommendation for grad school.")
+            .dateRequested(dateRequested)
+            .dateNeeded(dateNeeded)
+            .done(false)
+            .build();
+
+    recommendationRequestRepository.save(request);
+
+    mockMvc
+        .perform(delete("/api/recommendationrequest?id=1").with(csrf()))
+        .andExpect(status().isOk());
+
+    mockMvc.perform(get("/api/recommendationrequest?id=1")).andExpect(status().isNotFound());
+  }
+}

--- a/src/test/java/edu/ucsb/cs156/example/web/RecommendationRequestWebIT.java
+++ b/src/test/java/edu/ucsb/cs156/example/web/RecommendationRequestWebIT.java
@@ -1,0 +1,67 @@
+package edu.ucsb.cs156.example.web;
+
+import static com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat;
+
+import edu.ucsb.cs156.example.WebTestCase;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.ClassMode;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@ActiveProfiles("integration")
+@DirtiesContext(classMode = ClassMode.BEFORE_EACH_TEST_METHOD)
+public class RecommendationRequestWebIT extends WebTestCase {
+
+  @Test
+  public void admin_user_can_create_edit_delete_recommendation_request() throws Exception {
+    setupUser(true);
+
+    page.getByText("Recommendation Request").click();
+
+    page.getByText("Create RecommendationRequest").click();
+    assertThat(page.getByText("Create New RecommendationRequest")).isVisible();
+
+    page.getByTestId("RecommendationRequestForm-requesterEmail").fill("student@ucsb.edu");
+    page.getByTestId("RecommendationRequestForm-professorEmail").fill("professor@ucsb.edu");
+    page.getByTestId("RecommendationRequestForm-explanation").fill("Applying to grad school");
+    page.getByTestId("RecommendationRequestForm-dateRequested").fill("2024-01-01T00:00");
+    page.getByTestId("RecommendationRequestForm-dateNeeded").fill("2024-05-01T00:00");
+    page.getByTestId("RecommendationRequestForm-submit").click();
+
+    assertThat(page.getByTestId("RecommendationRequestTable-cell-row-0-col-requesterEmail"))
+        .hasText("student@ucsb.edu");
+
+    page.getByTestId("RecommendationRequestTable-cell-row-0-col-Edit-button").click();
+    assertThat(page.getByText("Edit RecommendationRequest")).isVisible();
+
+    page.getByTestId("RecommendationRequestForm-explanation")
+        .fill("Updated: applying for fellowship");
+    page.getByTestId("RecommendationRequestForm-submit").click();
+
+    assertThat(page.getByTestId("RecommendationRequestTable-cell-row-0-col-explanation"))
+        .hasText("Updated: applying for fellowship");
+
+    page.getByTestId("RecommendationRequestTable-cell-row-0-col-Delete-button").click();
+
+    assertThat(page.getByTestId("RecommendationRequestTable-cell-row-0-col-requesterEmail"))
+        .not()
+        .isVisible();
+  }
+
+  @Test
+  public void regular_user_cannot_create_recommendation_request() throws Exception {
+    setupUser(false);
+
+    page.getByText("Recommendation Request").click();
+
+    assertThat(page.getByText("Create RecommendationRequest")).not().isVisible();
+    assertThat(page.getByTestId("RecommendationRequestTable-cell-row-0-col-requesterEmail"))
+        .not()
+        .isVisible();
+  }
+}


### PR DESCRIPTION
Added end-to-end test for RecommendationRequest's create, edit, delete as admin, 
and verifying regular user cannot create. Tests pass as seen in screenshot.

Closes #140

<img width="1470" height="322" alt="image" src="https://github.com/user-attachments/assets/e5ad9b09-56b7-4019-b9d9-8a0ee97a378f" />
